### PR TITLE
Update WindowsTab.astro

### DIFF
--- a/src/components/pages/download/WindowsTab.astro
+++ b/src/components/pages/download/WindowsTab.astro
@@ -20,7 +20,7 @@ import Tab from "./Tab.astro";
                 This warning is entirely harmless and only shows because the app
                 is not signed. Signing it would cost us <a
                     href="https://shop.certum.eu/data-safety/code-signing-certificates/certum-ev-code-sigining.html"
-                    >upwards of 300€/year</a
+                    >upwards of €300/year</a
                 >.
             </p>
         </Card>


### PR DESCRIPTION
Fix the euro sign (€) as ruled on https://publications.europa.eu/code/en/en-370303.htm