### PR TITLE
Add plugin READMEs

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
         "@astrojs/sitemap": "^1.2.1",
         "@astrojs/svelte": "^2.1.0",
         "astro": "^2.3.0",
+        "marked": "^8.0.1",
         "normalize.css": "^8.0.1",
         "svelte": "^3.54.0"
     },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,5 +1,9 @@
 lockfileVersion: '6.0'
 
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
 dependencies:
   '@astrojs/cloudflare':
     specifier: ^6.2.2
@@ -16,6 +20,9 @@ dependencies:
   astro:
     specifier: ^2.3.0
     version: 2.3.0
+  marked:
+    specifier: ^8.0.1
+    version: 8.0.1
   normalize.css:
     specifier: ^8.0.1
     version: 8.0.1
@@ -2007,6 +2014,12 @@ packages:
 
   /markdown-table@3.0.3:
     resolution: {integrity: sha512-Z1NL3Tb1M9wH4XESsCDEksWoKTdlUafKc4pt0GRwjUyXaCFZ+dc3g2erqB6zm3szA2IUSi7VnPI+o/9jnxh9hw==}
+    dev: false
+
+  /marked@8.0.1:
+    resolution: {integrity: sha512-eEbeEb/mJwh+sNLEhHOWtxMgjN/NEwZUBs1nkiIH2sTQTq07KmPMQ48ihyvo5+Ya56spVOPhunfGr6406crCVA==}
+    engines: {node: '>= 16'}
+    hasBin: true
     dev: false
 
   /mdast-util-definitions@5.1.2:

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -75,7 +75,6 @@ const structuredData = JSON.stringify({
             rel="canonical"
             href={new URL(Astro.url.pathname, Astro.site).toString()}
         />
-
     </head>
 
     <body>
@@ -138,6 +137,7 @@ const structuredData = JSON.stringify({
 
         --light-fg0: #644735;
         --light-fg0-muted: #64473566;
+        --light-fg0-muted2: #64473525;
         --light-fg1: #503829;
 
         --light-grey0: #a79a83;
@@ -181,6 +181,7 @@ const structuredData = JSON.stringify({
 
         --dark-fg0: #d4be98;
         --dark-fg0-muted: #d4be9866;
+        --dark-fg0-muted2: #d4be9825;
         --dark-fg1: #ddc7a0;
 
         --dark-grey0: #7c6f64;
@@ -239,6 +240,8 @@ const structuredData = JSON.stringify({
         --accentPurpleRgb: var(--light-accentPurpleRgb);
 
         --fg0: var(--light-fg0);
+        --fg0-muted: var(--light-fg0-muted);
+        --fg0-muted2: var(--light-fg0-muted2);
         --fg1: var(--light-fg1);
 
         --grey0: var(--light-grey0);
@@ -285,6 +288,7 @@ const structuredData = JSON.stringify({
 
         --fg0: var(--dark-fg0);
         --fg0-muted: var(--dark-fg0-muted);
+        --fg0-muted2: var(--dark-fg0-muted2);
         --fg1: var(--dark-fg1);
 
         --grey0: var(--dark-grey0);

--- a/src/pages/plugin-readmes.json.astro
+++ b/src/pages/plugin-readmes.json.astro
@@ -1,0 +1,5 @@
+---
+import { PLUGIN_READMES_JSON_URL, StatusCodes } from "scripts/constants";
+
+return Astro.redirect(PLUGIN_READMES_JSON_URL, StatusCodes.Found);
+---

--- a/src/pages/plugins/[plugin].astro
+++ b/src/pages/plugins/[plugin].astro
@@ -30,7 +30,7 @@ const readmeHtml = readme && parseMarkdown(readme);
 
     {
         readmeHtml ? (
-            <section set:html={readmeHtml} />
+            <article set:html={readmeHtml} />
         ) : (
             <p class="desc">{p.description}</p>
         )
@@ -51,7 +51,7 @@ const readmeHtml = readme && parseMarkdown(readme);
         line-height: 1em;
     }
 
-    section {
+    article {
         background: var(--bg0);
         padding: 2em;
         border-radius: 8px;
@@ -64,7 +64,7 @@ const readmeHtml = readme && parseMarkdown(readme);
      * Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (https://sindresorhus.com)
      */
 
-    section :global(:is(h1, h2, h3, h4, h5, h6)) {
+    article :global(:is(h1, h2, h3, h4, h5, h6)) {
         margin-top: 24px;
         margin-bottom: 16px;
         font-weight: 600;
@@ -72,45 +72,45 @@ const readmeHtml = readme && parseMarkdown(readme);
         border-bottom: 1px solid var(--fg0-muted2);
     }
 
-    section :global(h1) {
+    article :global(h1) {
         margin: 0.67em 0;
         font-weight: 600;
         padding-bottom: 0.3em;
         font-size: 2em;
     }
 
-    section :global(h2) {
+    article :global(h2) {
         font-weight: 600;
         padding-bottom: 0.3em;
         font-size: 1.5em;
     }
 
-    section :global(h3) {
+    article :global(h3) {
         font-weight: 600;
         font-size: 1.25em;
     }
 
-    section :global(h4) {
+    article :global(h4) {
         font-weight: 600;
         font-size: 1em;
     }
 
-    section :global(h5) {
+    article :global(h5) {
         font-weight: 600;
         font-size: 0.875em;
     }
 
-    section :global(h6) {
+    article :global(h6) {
         font-weight: 600;
         font-size: 0.85em;
     }
 
-    section :global(p) {
+    article :global(p) {
         margin-top: 0;
         margin-bottom: 10px;
     }
 
-    section :global(img) {
+    article :global(img) {
         max-width: 100%;
     }
 </style>

--- a/src/pages/plugins/[plugin].astro
+++ b/src/pages/plugins/[plugin].astro
@@ -18,8 +18,8 @@ if (!p) {
 }
 const readme = await fetchPluginReadme(p.name);
 const processedReadme = readme?.replace(
-    /\n(https:\/\/github\.com\/\S+\/assets\/\d+\/[\w-]+)/g,
-    '<video controls><source src="$1" type="video/mp4"></video>'
+    new RegExp(String.raw`\n(https://github\.com/\S+/assets/\d+/[\w-]+)`, "g"),
+    '\n<video controls><source src="$1" type="video/mp4"></video>\n'
 );
 
 const readmeHtml = processedReadme && parseMarkdown(processedReadme);

--- a/src/pages/plugins/[plugin].astro
+++ b/src/pages/plugins/[plugin].astro
@@ -1,7 +1,8 @@
 ---
+import { parse as parseMarkdown } from "marked";
 import { cacheResponseFor, HOURS, DAYS } from "scripts/cache";
 import Layout from "layouts/Layout.astro";
-import { fetchPlugins } from "scripts/data";
+import { fetchPluginReadme, fetchPlugins } from "scripts/data";
 import { humanFriendlyJoin } from "scripts/text";
 
 const pluginName = Astro.params.plugin;
@@ -15,6 +16,8 @@ if (!p) {
 } else {
     cacheResponseFor(Astro.response, 1 * DAYS);
 }
+const readme = await fetchPluginReadme(p.name);
+const readmeHtml = readme && parseMarkdown(readme);
 ---
 
 <Layout title={p.name} description={p.description}>
@@ -25,9 +28,13 @@ if (!p) {
         </p>
     </div>
 
-    <p class="desc">
-        {p.description}
-    </p>
+    {
+        readmeHtml ? (
+            <section set:html={readmeHtml} />
+        ) : (
+            <p class="desc">{p.description}</p>
+        )
+    }
 
     <h2 class="h">Installation</h2>
     <p>
@@ -42,5 +49,68 @@ if (!p) {
         margin: 2em 0 0.5em;
         font-size: 2em;
         line-height: 1em;
+    }
+
+    section {
+        background: var(--bg0);
+        padding: 2em;
+        border-radius: 8px;
+        box-shadow: 0 0 0 1px var(--grey0);
+    }
+
+    /*
+     * most of these styles are adapted from https://github.com/sindresorhus/github-markdown-css/blob/main/github-markdown-dark.css
+     * SPDX-License-Identifier: MIT
+     * Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (https://sindresorhus.com)
+     */
+
+    section :global(:is(h1, h2, h3, h4, h5, h6)) {
+        margin-top: 24px;
+        margin-bottom: 16px;
+        font-weight: 600;
+        line-height: 1.25;
+        border-bottom: 1px solid var(--grey0);
+    }
+
+    section :global(h1) {
+        margin: 0.67em 0;
+        font-weight: 600;
+        padding-bottom: 0.3em;
+        font-size: 2em;
+    }
+
+    section :global(h2) {
+        font-weight: 600;
+        padding-bottom: 0.3em;
+        font-size: 1.5em;
+    }
+
+    section :global(h3) {
+        font-weight: 600;
+        font-size: 1.25em;
+    }
+
+    section :global(h4) {
+        font-weight: 600;
+        font-size: 1em;
+    }
+
+    section :global(h5) {
+        font-weight: 600;
+        font-size: 0.875em;
+    }
+
+    section :global(h6) {
+        font-weight: 600;
+        font-size: 0.85em;
+    }
+
+    section :global(p) {
+        margin-top: 0;
+        margin-bottom: 10px;
+    }
+
+    section :global(img) {
+        max-width: 100%;
     }
 </style>

--- a/src/pages/plugins/[plugin].astro
+++ b/src/pages/plugins/[plugin].astro
@@ -1,6 +1,6 @@
 ---
 import { parse as parseMarkdown } from "marked";
-import { cacheResponseFor, HOURS, DAYS } from "scripts/cache";
+import { cacheResponseFor, HOURS, MINUTES } from "scripts/cache";
 import Layout from "layouts/Layout.astro";
 import { fetchPluginReadme, fetchPlugins } from "scripts/data";
 import { humanFriendlyJoin } from "scripts/text";
@@ -11,13 +11,18 @@ const plugins = await fetchPlugins();
 
 const p = plugins.find(p => p.name === pluginName);
 if (!p) {
-    cacheResponseFor(Astro.response, 1 * HOURS);
+    cacheResponseFor(Astro.response, 5 * MINUTES);
     return new Response(null, { status: 404 });
 } else {
-    cacheResponseFor(Astro.response, 1 * DAYS);
+    cacheResponseFor(Astro.response, 1 * HOURS);
 }
 const readme = await fetchPluginReadme(p.name);
-const readmeHtml = readme && parseMarkdown(readme);
+const processedReadme = readme?.replace(
+    /\n(https:\/\/github\.com\/\S+\/assets\/\d+\/[\w-]+)/g,
+    '<video controls><source src="$1" type="video/mp4"></video>'
+);
+
+const readmeHtml = processedReadme && parseMarkdown(processedReadme);
 ---
 
 <Layout title={p.name} description={p.description}>
@@ -110,7 +115,7 @@ const readmeHtml = readme && parseMarkdown(readme);
         margin-bottom: 10px;
     }
 
-    article :global(img) {
+    article :global(:is(img, video)) {
         max-width: 100%;
     }
 </style>

--- a/src/pages/plugins/[plugin].astro
+++ b/src/pages/plugins/[plugin].astro
@@ -69,7 +69,7 @@ const readmeHtml = readme && parseMarkdown(readme);
         margin-bottom: 16px;
         font-weight: 600;
         line-height: 1.25;
-        border-bottom: 1px solid var(--grey0);
+        border-bottom: 1px solid var(--fg0-muted2);
     }
 
     section :global(h1) {

--- a/src/scripts/constants.ts
+++ b/src/scripts/constants.ts
@@ -10,6 +10,8 @@ export const DOWNLOAD_BASE =
 
 export const PLUGINS_JSON_URL =
     "https://raw.githubusercontent.com/Vencord/builds/main/plugins.json";
+export const PLUGIN_READMES_JSON_URL =
+    "https://raw.githubusercontent.com/Vencord/builds/main/plugin-readmes.json";
 
 export const FIREFOX_WEBSTORE_URL =
     "https://addons.mozilla.org/en-GB/firefox/addon/vencord-web";

--- a/src/scripts/data.ts
+++ b/src/scripts/data.ts
@@ -1,10 +1,18 @@
-import { PLUGINS_JSON_URL } from "./constants";
+import { PLUGINS_JSON_URL, PLUGIN_READMES_JSON_URL } from "./constants";
 import { PluginData } from "./types";
 
 export async function fetchPlugins() {
     const res = await fetch(PLUGINS_JSON_URL);
-
     if (!res.ok) throw new Error("Failed to fetch plugins.json: " + res.status);
 
     return res.json() as Promise<PluginData[]>;
+}
+
+export async function fetchPluginReadme(plugin: string) {
+    const res = await fetch(PLUGIN_READMES_JSON_URL);
+    if (!res.ok)
+        throw new Error("Failed to fetch plugin-readmes.json: " + res.status);
+
+    const readmes = await res.json<any>();
+    return readmes[plugin] as string | undefined;
 }


### PR DESCRIPTION
this is already mergeable now technically, but will likely need more adjustements to the css in the future for additional markdown features like ul/ol, etc

right now, ThemeAttributes and ServerProfiles are the only plugins that have a README, so writing README for more plugins would be the next step after merging this

![image](https://github.com/Vencord/vencord.dev/assets/45497981/a645ea98-5f6d-4be6-a862-a9b9e7919814)
