### PR TITLE
Fix platform flash on download page

### DIFF
--- a/src/components/pages/download/index.svelte
+++ b/src/components/pages/download/index.svelte
@@ -1,8 +1,7 @@
 <script lang="ts">
+    import { onMount } from "svelte";
     import { writable } from "svelte/store";
     import { fade } from "svelte/transition";
-
-    import { IS_SERVER } from "scripts/constants";
 
     const options = ["Windows", "Linux", "Mac", "Browser"] as const;
 
@@ -13,20 +12,22 @@
         Browser: "Orange",
     };
 
-    const initialValue = IS_SERVER
-        ? "Windows"
-        : (() => {
-              const stored = localStorage.platform;
-              if (stored && options.includes(stored)) return stored;
+    const selected = writable<string | null>(null);
 
-              const platform = navigator.platform.toLowerCase();
-              if (platform.includes("linux")) return "Linux";
-              if (platform.includes("mac")) return "Mac";
-              return "Windows";
-          })();
+    onMount(() => {
+        const getInitialPlatform = (): string => {
+            const stored = localStorage.platform;
+            if (stored && options.includes(stored)) return stored;
 
-    const selected = writable(initialValue);
-    if (!IS_SERVER) selected.subscribe(v => (localStorage.platform = v));
+            const platform = navigator.platform.toLowerCase();
+            if (platform.includes("linux")) return "Linux";
+            if (platform.includes("mac")) return "Mac";
+            return "Windows";
+        };
+
+        selected.set(getInitialPlatform());
+        selected.subscribe(v => (localStorage.platform = v));
+    });
 </script>
 
 <div class="container">


### PR DESCRIPTION
It is arguably prettier for the platform info to show up with a nice transition than changing from one to another. We could theoretically make a not-loaded state that would be sent from the server so there is not an empty space there until it loads, then transition nicely to the actual platform nicely. What is the opinion of you all on this?

https://github.com/Vencord/vencord.dev/assets/49836430/331d101c-cc8c-4732-b743-f6b27265c1ba

