### PR TITLE
Added option for wget in Linux install docs

### DIFF
--- a/src/components/pages/download/LinuxTab.astro
+++ b/src/components/pages/download/LinuxTab.astro
@@ -23,14 +23,12 @@ sudo XDG_CONFIG_HOME="$XDG_CONFIG_HOME" ./vencord-installer --install
         </p>
         
         <h3>curl</h3>
-    
         <CodeBlock
             code={'sh -c "$(curl -sS https://raw.githubusercontent.com/Vendicated/VencordInstaller/main/install.sh)"'}
             client:load
         />
 
         <h3>wget</h3>
-
         <CodeBlock
             code={'wget -O - https://raw.githubusercontent.com/Vendicated/VencordInstaller/main/install.sh | bash'}
             client:load

--- a/src/components/pages/download/LinuxTab.astro
+++ b/src/components/pages/download/LinuxTab.astro
@@ -21,8 +21,18 @@ sudo XDG_CONFIG_HOME="$XDG_CONFIG_HOME" ./vencord-installer --install
             {}
             <Code>bash</Code>)
         </p>
+        
+        <h3>curl</h3>
+    
         <CodeBlock
             code={'sh -c "$(curl -sS https://raw.githubusercontent.com/Vendicated/VencordInstaller/main/install.sh)"'}
+            client:load
+        />
+
+        <h3>wget</h3>
+
+        <CodeBlock
+            code={'wget -O - https://raw.githubusercontent.com/Vendicated/VencordInstaller/main/install.sh | bash'}
             client:load
         />
 


### PR DESCRIPTION
Allows users to choose between using curl

```bash
sh -c "$(curl -sS https://raw.githubusercontent.com/Vendicated/VencordInstaller/main/install.sh)"
```
or wget
```bash
wget -O - https://raw.githubusercontent.com/Vendicated/VencordInstaller/main/install.sh | bash
```
 to install Vencord on Linux.