### PR TITLE
Remove firefox from FAQ

### DIFF
--- a/src/content/faq/3_web_support.md
+++ b/src/content/faq/3_web_support.md
@@ -3,6 +3,6 @@ title: Can I use this on the web version of Discord?
 tags: browser, web, firefox, chrome, extension, userscript
 ---
 
-Yes! We provide extensions for Firefox & Chromium based browsers and a UserScript build.
+Yes! We provide extensions for Chromium based browsers and a UserScript build.
 
 See our [download page](/download) for more info!


### PR DESCRIPTION
Since firefox bombed the extension and the only way to get it now is through a devbuild it's better to just remove it from FAQ too, especially that it was removed from the download page.