### PR TITLE
feat: Third-Party Resources

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
         "svelte": "^3.54.0"
     },
     "devDependencies": {
-        "@cloudflare/workers-types": "^4.20230404.0"
+        "@cloudflare/workers-types": "^4.20230404.0",
+        "shiki": "^1.1.7"
     }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -34,6 +34,9 @@ devDependencies:
   '@cloudflare/workers-types':
     specifier: ^4.20230404.0
     version: 4.20230404.0
+  shiki:
+    specifier: ^1.1.7
+    version: 1.1.7
 
 packages:
 
@@ -784,6 +787,10 @@ packages:
       picomatch: 2.3.1
       rollup: 3.20.7
     dev: false
+
+  /@shikijs/core@1.1.7:
+    resolution: {integrity: sha512-gTYLUIuD1UbZp/11qozD3fWpUTuMqPSf3svDMMrL0UmlGU7D9dPw/V1FonwAorCUJBltaaESxq90jrSjQyGixg==}
+    dev: true
 
   /@sveltejs/vite-plugin-svelte@2.0.3(svelte@3.57.0)(vite@4.3.1):
     resolution: {integrity: sha512-o+cguBFdwIGtRbNkYOyqTM7KvRUffxh5bfK4oJsWKG2obu+v/cbpT03tJrGl58C7tRXo/aEC0/axN5FVHBj0nA==}
@@ -3102,6 +3109,12 @@ packages:
       vscode-oniguruma: 1.7.0
       vscode-textmate: 6.0.0
     dev: false
+
+  /shiki@1.1.7:
+    resolution: {integrity: sha512-9kUTMjZtcPH3i7vHunA6EraTPpPOITYTdA5uMrvsJRexktqP0s7P3s9HVK80b4pP42FRVe03D7fT3NmJv2yYhw==}
+    dependencies:
+      '@shikijs/core': 1.1.7
+    dev: true
 
   /signal-exit@3.0.7:
     resolution: {integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==}

--- a/src/components/Card.svelte
+++ b/src/components/Card.svelte
@@ -4,7 +4,7 @@
         Error = "#ec4144",
         Success = "#2d7c46",
         Info = "#5865f2",
-        Blank = "#aaaaaa",
+        Blank = "#575757",
     }
 </script>
 

--- a/src/components/Card.svelte
+++ b/src/components/Card.svelte
@@ -22,6 +22,7 @@
 <style define:vars={{ border, background }}>
     div {
         width: 100%;
+        overflow-x: auto;
         border: 2px solid var(--border);
         border-radius: 8px;
         padding: 0.5rem 1rem;

--- a/src/components/NavBar.astro
+++ b/src/components/NavBar.astro
@@ -4,6 +4,7 @@ const navLinks = {
     plugins: ["Plugins", "accentBlue"],
     faq: ["FAQ", "accentAqua"],
     cloud: ["Cloud", "accentYellow"],
+    "third-party": ["Third-Party", "accentOrange"],
 };
 
 const page = Astro.url.pathname.split("/")[1];

--- a/src/components/ShikiCodeBlocks.svelte
+++ b/src/components/ShikiCodeBlocks.svelte
@@ -1,0 +1,71 @@
+<script script lang="ts">
+    import Card, { CardKind } from "./Card.svelte";
+
+    export let code: string;
+    export let lang: string;
+    export let highlighter;
+
+    const highlightedCode = highlighter.codeToHtml(code, {
+        lang: lang,
+        theme: 'catppuccin-frappe',
+    })
+
+    function copyCode() {
+        navigator.clipboard.writeText(code);
+        didCopy = true;
+    }
+
+    let didCopy = false;
+</script>
+
+<div>
+    <Card kind={CardKind.Blank}>
+        {@html highlightedCode}
+        
+        <button on:click={copyCode}>
+            <svg height="24" viewBox="0 -960 960 960" width="24">
+                {#if !didCopy}
+                    <title>Copy to Clipboard</title>
+                    <path
+                        fill="currentColor"
+                        d="M360-240q-33 0-56.5-23.5T280-320v-480q0-33 23.5-56.5T360-880h360q33 0 56.5 23.5T800-800v480q0 33-23.5 56.5T720-240H360Zm0-80h360v-480H360v480ZM200-80q-33 0-56.5-23.5T120-160v-560h80v560h440v80H200Zm160-240v-480 480Z"
+                    />
+                {:else}
+                    <title>Code copied!</title>
+                    <path
+                        fill="currentColor"
+                        d="M382-240 154-468l57-57 171 171 367-367 57 57-424 424Z"
+                    />
+                {/if}
+            </svg>
+        </button>
+    </Card>
+</div>
+
+<style>
+    div {
+        position: relative;
+    }
+
+    code,
+    pre {
+        overflow-wrap: anywhere;
+        white-space: pre-wrap;
+        line-height: 1.25em;
+    }
+
+    button {
+        all: unset;
+        cursor: pointer;
+        position: absolute;
+        top: 4px;
+        right: 4px;
+
+        color: var(--fg0-muted);
+        transition: 200ms color ease-in-out;
+    }
+
+    button:is(:hover, :focus) {
+        color: var(--fg0);
+    }
+</style>

--- a/src/components/ShikiCodeBlocks.svelte
+++ b/src/components/ShikiCodeBlocks.svelte
@@ -7,7 +7,7 @@
 
     const highlightedCode = highlighter.codeToHtml(code, {
         lang: lang,
-        theme: 'catppuccin-frappe',
+        theme: 'catppuccin-frappe'
     })
 
     function copyCode() {

--- a/src/components/pages/download/LinuxTab.astro
+++ b/src/components/pages/download/LinuxTab.astro
@@ -1,7 +1,13 @@
 ---
 import Code from "components/Code.astro";
 import Tab from "./Tab.astro";
-import CodeBlock from "components/CodeBlock.svelte";
+import CodeBlock from "components/ShikiCodeBlocks.svelte";
+import { getHighlighter } from "shiki";
+
+const highlighter = await getHighlighter({
+    themes: ["catppuccin-frappe"],
+    langs: ["shell"],
+});
 ---
 
 <Tab>
@@ -15,6 +21,8 @@ import CodeBlock from "components/CodeBlock.svelte";
         </p>
         <CodeBlock
             code={'sh -c "$(curl -sS https://raw.githubusercontent.com/Vendicated/VencordInstaller/main/install.sh)"'}
+            lang="shell"
+            {highlighter}
             client:load
         />
     </div>

--- a/src/components/pages/download/LinuxTab.astro
+++ b/src/components/pages/download/LinuxTab.astro
@@ -11,7 +11,7 @@ const highlighter = await getHighlighter({
 ---
 
 <Tab>
-    <div slot="header">
+    <div class="tab-container" slot="header">
         <p>
             Open your terminal and run the following command. Then follow the
             instructions in your terminal. If you're using fish, switch to bash
@@ -20,7 +20,7 @@ const highlighter = await getHighlighter({
             <Code>bash</Code>)
         </p>
         <CodeBlock
-            code={'sh -c "$(curl -sS https://raw.githubusercontent.com/Vendicated/VencordInstaller/main/install.sh)"'}
+            code={'sh -c "$(curl -sS\nhttps://raw.githubusercontent.com/Vendicated/VencordInstaller/main/install.sh)"'}
             lang="shell"
             {highlighter}
             client:load
@@ -32,5 +32,9 @@ const highlighter = await getHighlighter({
     h3 {
         margin: 1em 0 0.5em;
         font-size: 2em;
+    }
+
+    .tab-container {
+        max-width: 100%;
     }
 </style>

--- a/src/components/pages/thirdParty/Information.svelte
+++ b/src/components/pages/thirdParty/Information.svelte
@@ -1,0 +1,70 @@
+<script lang="ts">
+    import Shiki from "../../ShikiCodeBlocks.svelte"
+
+    export let type: string;
+    export let code: string;
+    export let githubRepo: string;
+    export let highlighter;
+</script>
+
+<section>
+    <hr/>
+    <h3 class="install-header">Install</h3>
+    {#if type === "plugin"}
+        <div class="instruction">
+            <p>Run the following command inside of your Vencord's <code class="highlight">src/userplugins</code>:</p>
+            <Shiki {highlighter} lang="shell" code={`git clone ${githubRepo}`}></Shiki>
+        </div>
+        <div class="instruction">
+            <p>Then, re-build and inject</p>
+            <Shiki {highlighter} lang="shell" code={`pnpm build\npnpm inject`}></Shiki>
+        </div>
+
+    {:else if type === "js-snippet"}
+        <p>Run the following snippet in your Developer tools (<code class="highlight">Control + Shift + I</code>)</p>
+        <Shiki {highlighter} lang="javascript" {code}></Shiki>
+        
+    {:else if type === "css-snippet"}
+        <section>
+            <p class="install-info">Copy this snippet and put it into your <code class="highlight">Quick CSS</code></p>
+            <Shiki {highlighter} lang="css" {code}></Shiki>
+        </section>
+    {/if}
+</section>
+
+<style>
+    p {
+        line-height: normal;
+        margin: 1px;
+    }
+    
+    hr {
+        display: block;
+        height: 1px;
+        border: 0;
+        border-top: 1.5px solid var(--grey2);
+        margin: 1.5em 0;
+        padding: 0;
+    }
+
+    .install-header {
+        margin: 10px 0;
+        font-size: 1.5rem;
+        line-height: inherit;
+        margin-top: 1.25em;
+    }
+
+    .install-info, .instruction {
+        margin-bottom: 1em;
+    }
+
+    .highlight {
+        background-color: var(--bg4);
+        color: var(--accentAqua);
+        border-radius: 8px;
+        font-family: unset;
+        text-align: center;
+        padding: 0.05em 0.3em;
+    }
+
+</style>

--- a/src/components/pages/thirdParty/ResourceCards.svelte
+++ b/src/components/pages/thirdParty/ResourceCards.svelte
@@ -8,6 +8,7 @@
 
 <script lang="ts">
     import type { MutualResource, PluginData } from "scripts/types";
+    import { fade } from "svelte/transition";
 
     export let type: ResourceTypes = ResourceTypes.Plugin;
     export let files;
@@ -105,7 +106,7 @@
 
     <section class="resource-grid">
         {#each filteredResources as r}
-            <div class="resource">
+            <div in:fade={{ duration: 150 }} class="resource">
                 <a
                     class="resource-content resource-link"
                     href={`/third-party/${r.default.slug}`}

--- a/src/components/pages/thirdParty/ResourceCards.svelte
+++ b/src/components/pages/thirdParty/ResourceCards.svelte
@@ -1,0 +1,234 @@
+<script context="module" lang="ts">
+    export const enum ResourceTypes {
+        Plugin = "Plugins",
+        JS = "JS Snippets",
+        CSS = "CSS Snippets",
+    }
+</script>
+
+<script lang="ts">
+    export let type: ResourceTypes = ResourceTypes.Plugin;
+    export let files;
+
+    const resourceMap = {
+        [ResourceTypes.Plugin]: files.plugins,
+        [ResourceTypes.JS]: files.jsSnippet,
+        [ResourceTypes.CSS]: files.cssSnippet,
+    };
+
+    let resources = resourceMap[type];
+
+</script>
+
+<section class="resource-cards">
+    <section class="resource-grid">
+        {#each resources as r}
+            <div class="resource">
+                <a
+                    class="resource-content resource-link"
+                    href={`/third-party/${r.default.slug}`}
+                >
+                    <h3 class="p-label-l">
+                        {r.name}
+                    </h3>
+                    <span class="author ellipsis-overflow">
+                        {r.authors.map(a => a.name).join(", ")}
+                    </span>
+                    <p class="description ellipsis-overflow">
+                        {r.description}
+                    </p>
+                </a>
+            </div>
+        {/each}
+    </section>
+</section>
+
+
+
+<style>
+    .resource-cards {
+        margin-top: 1em;
+    }
+
+    .buttons {
+        display: flex;
+        justify-content: center;
+        gap: 1rem;
+        padding: 1em;
+        flex-wrap: wrap;
+    }
+
+    .buttons a {
+        text-decoration: none;
+        color: black;
+        transition: filter 0.2s ease-in-out;
+    }
+
+
+    h2 {
+        margin-block: 0.2em;
+        font-size: 2em;
+    }
+
+    .resource-grid {
+        display: grid;
+        grid-template-columns: repeat(3, minmax(0, 1fr));
+        grid-auto-columns: 1fr;
+        grid-gap: 1em;
+    }
+
+    @media screen and (max-width: 1200px) {
+        .resource-grid {
+            grid-template-columns: repeat(2, minmax(0, 1fr));
+        }
+    }
+
+    @media screen and (max-width: 800px) {
+        .resource-grid {
+            grid-template-columns: minmax(0, 1fr);
+        }
+    }
+
+    .resource {
+        display: flex;
+        flex-direction: column;
+        background: var(--bg4);
+
+        border: 1px solid var(--fg0-muted);
+
+        border-radius: 8px;
+        padding: 1em;
+        padding-bottom: 2em;
+
+        transition: 200ms box-shadow cubic-bezier(0.25, 0.8, 0.25, 1);
+    }
+
+    .resource:hover {
+        box-shadow: rgba(0, 0, 0, 0.35) 0px 5px 15px;
+    }
+
+    .resource-link {
+        color: unset;
+        text-decoration: unset;
+    }
+
+    .resource-screenshot {
+        object-fit: cover;
+        width: 100%;
+        border-radius: 4px;
+        margin-bottom: 1em;
+    }
+
+    .resource-content {
+        display: flex;
+        flex-direction: column;
+        position: relative;
+    }
+
+    h3 {
+        margin: 0;
+        word-wrap: break-word;
+        line-height: normal;
+    }
+
+    .resource-badges {
+        display: flex;
+        gap: 0.5em;
+
+        position: absolute;
+        bottom: 1em;
+    }
+
+    .ellipsis-overflow {
+        overflow: hidden;
+        text-overflow: ellipsis;
+    }
+
+    .author {
+        white-space: nowrap;
+    }
+
+    .author::before {
+        content: "by ";
+        color: var(--grey2);
+    }
+
+    .description {
+        font-size: 0.9em;
+        filter: brightness(90%);
+        margin-bottom: 0;
+        display: -webkit-box;
+        -webkit-line-clamp: 3;
+        line-clamp: 3;
+        -webkit-box-orient: vertical;
+        box-orient: vertical;
+    }
+
+    svg {
+        width: 1.5em;
+        height: 1.5em;
+        shape-rendering: auto;
+        color: var(--color);
+    }
+
+    .criteria {
+        display: flex;
+        flex-direction: row;
+    }
+
+    @media screen and (max-width: 400px) {
+        .criteria {
+            flex-direction: column;
+        }
+    }
+
+    .criteria label {
+        display: flex;
+        gap: 0.5em;
+        flex-direction: row;
+        align-items: center;
+        white-space: nowrap;
+    }
+
+    .criteria label:not(:last-child) {
+        margin-right: 1em;
+    }
+
+    .search {
+        position: relative;
+        height: 5em;
+    }
+
+    .search :is(svg, input) {
+        position: absolute;
+    }
+
+    .search svg {
+        left: 0.5em;
+        top: 2.05em;
+        z-index: 2;
+        color: var(--grey0);
+        height: 1em;
+    }
+
+    .search input {
+        text-indent: 1.5em;
+        background: var(--bg0);
+        color: var(--fg0);
+        border: none;
+        border-radius: 8px;
+        box-sizing: border-box;
+        width: 100%;
+        margin: 1em 0;
+        padding: 1em;
+    }
+
+    .search input::placeholder {
+        color: var(--grey0);
+    }
+
+    /* input[type="checkbox"] {
+        height: 1em;
+        width: 1em;
+    } */
+</style>

--- a/src/components/pages/thirdParty/Resources.svelte
+++ b/src/components/pages/thirdParty/Resources.svelte
@@ -2,7 +2,6 @@
     import Cards, { ResourceTypes } from "./ResourceCards.svelte";
 
     import { writable } from "svelte/store";
-    import { fade } from "svelte/transition";
     import { IS_SERVER } from "scripts/constants";
 
     export let files;
@@ -42,17 +41,11 @@
 
     <section>
         {#if $selected === "Plugins"}
-            <div in:fade={{ duration: 150 }}>
-                <Cards {files} type={ResourceTypes.Plugin} />
-            </div>
+            <Cards {files} type={ResourceTypes.Plugin} />
         {:else if $selected === "JS Snippets"}
-            <div in:fade={{ duration: 150 }}>
-                <Cards {files} type={ResourceTypes.JS} />
-            </div>
+            <Cards {files} type={ResourceTypes.JS} />
         {:else if $selected === "CSS Snippets"}
-            <div in:fade={{ duration: 150 }}>
-                <Cards {files} type={ResourceTypes.CSS} />
-            </div>
+            <Cards {files} type={ResourceTypes.CSS} />
         {/if}
     </section>
 </div>
@@ -72,7 +65,7 @@
         font-weight: var(--fontWeightSemiBold);
         letter-spacing: 0.02em;
 
-        padding: 0.3em 1.5rem;
+        padding: 0.4em 1.5rem;
         text-align: center;
         cursor: pointer;
         border: 1px solid var(--bg5);

--- a/src/components/pages/thirdParty/Resources.svelte
+++ b/src/components/pages/thirdParty/Resources.svelte
@@ -1,0 +1,108 @@
+<script lang="ts">
+    import Cards, { ResourceTypes } from "./ResourceCards.svelte";
+
+    import { writable } from "svelte/store";
+    import { fade } from "svelte/transition";
+    import { IS_SERVER } from "scripts/constants";
+
+    export let files;
+
+    const options = ["Plugins", "JS Snippets", "CSS Snippets"] as const;
+
+    const accents: { [option in (typeof options)[number]]: string } = {
+        "Plugins": "Blue",
+        "JS Snippets": "Yellow",
+        "CSS Snippets": "Green",
+    };
+
+    const initialValue = "Plugins"
+
+    const selected = writable(initialValue);
+    if (!IS_SERVER) selected.subscribe(v => (localStorage.platform = v));
+</script>
+
+<div class="container">
+    <slot name="title" />
+    <nav>
+        {#each options as option}
+            <label
+                class={$selected === option ? "selected" : ""}
+                style="--accent: var(--accent{accents[option]})"
+            >
+                <input
+                    type="radio"
+                    name="os"
+                    bind:group={$selected}
+                    value={option}
+                />
+                {option}
+            </label>
+        {/each}
+    </nav>
+
+    <section>
+        {#if $selected === "Plugins"}
+            <div in:fade={{ duration: 150 }}>
+                <Cards {files} type={ResourceTypes.Plugin} />
+            </div>
+        {:else if $selected === "JS Snippets"}
+            <div in:fade={{ duration: 150 }}>
+                <Cards {files} type={ResourceTypes.JS} />
+            </div>
+        {:else if $selected === "CSS Snippets"}
+            <div in:fade={{ duration: 150 }}>
+                <Cards {files} type={ResourceTypes.CSS} />
+            </div>
+        {/if}
+    </section>
+</div>
+
+<style>
+    .container {
+        display: flex;
+        flex-direction: column;
+    }
+
+    nav {
+        display: flex;
+    }
+
+    label {
+        font-size: 1em;
+        font-weight: var(--fontWeightSemiBold);
+        letter-spacing: 0.02em;
+
+        padding: 0.3em 1.5rem;
+        text-align: center;
+        cursor: pointer;
+        border: 1px solid var(--bg5);
+        border-right: none;
+        user-select: none;
+
+        background-color: var(--bg2);
+    }
+
+    @media screen and (max-width: 600px) {
+        label {
+            padding: 0.5em 0.75em;
+        }
+    }
+
+    label:first-child {
+        border-radius: 7px 0 0 7px;
+    }
+
+    label:last-child {
+        border-radius: 0 7px 7px 0;
+        border-right: 1px solid var(--bg5);
+    }
+
+    label.selected {
+        background-color: var(--accent);
+        color: var(--bg2);
+    }
+
+    input {
+        display: none;
+    }
+</style>

--- a/src/content/third-party/css-snippets/test1.json
+++ b/src/content/third-party/css-snippets/test1.json
@@ -1,7 +1,7 @@
 {
     "name": "Album as Spotify Controls Background",
     "description": "Use album cover as SpotifyControls background",
-    "tags": ["utility", "music"],
+    "tags": ["utility"],
     "authors": [{ "name": "Vee", "email": "author1@example.com" }],
     "dependencies": ["dependency1", "dependency2"],
     "hasPatches": true,

--- a/src/content/third-party/css-snippets/test1.json
+++ b/src/content/third-party/css-snippets/test1.json
@@ -1,0 +1,18 @@
+{
+    "name": "Album as Spotify Controls Background",
+    "description": "Use album cover as SpotifyControls background",
+    "tags": ["utility", "music"],
+    "authors": [{ "name": "Vee", "email": "author1@example.com" }],
+    "dependencies": ["dependency1", "dependency2"],
+    "hasPatches": true,
+    "hasCommands": false,
+    "required": false,
+    "enabledByDefault": true,
+    "target": "discordDesktop",
+    "filePath": "/path/to/plugin1",
+    "github": "https://github.com/coolig",
+    "code": "#vc-spotify-player {\n    --blur-amount: 2px; /* higher px = stronger blur, 0 = no blur */\n    --darken-percent: 0.8; /* 0 = album cover is not darkened, 1 = album cover is darkened fully (black) */\n}\n\n#vc-spotify-player {\n    background: transparent !important;\n    position: relative;\n}\n\n#vc-spotify-player > * {\n    position: relative;\n    z-index: 1;\n}\n\n#vc-spotify-player::after {\n    content: '';\n    position: absolute;\n    display: block;\n    height: 100%;\n    width: 100%;\n    top: 0;\n    left: 0;\n    background: linear-gradient(rgba(0, 0, 0, var(--darken-percent)),\n            rgba(0, 0, 0, var(--darken-percent))), var(--vc-spotify-track-image);\n    background-size: cover;\n    filter: blur(var(--blur-amount));\n    clip-path: inset(0);\n}",
+
+    "slug": "spotify",
+    "type": "css-snippet"
+}

--- a/src/content/third-party/js-snippets/test2.json
+++ b/src/content/third-party/js-snippets/test2.json
@@ -1,7 +1,7 @@
 {
     "name": "cool snippet ig",
     "description": "This is a random plugin with no specific purpose.",
-    "tags": ["random", "test", "utility"],
+    "tags": ["utility"],
     "authors": [{ "name": "Author1", "email": "author1@example.com" }],
     "dependencies": ["dependency1", "dependency2"],
     "hasPatches": true,

--- a/src/content/third-party/js-snippets/test2.json
+++ b/src/content/third-party/js-snippets/test2.json
@@ -1,0 +1,18 @@
+{
+    "name": "cool snippet ig",
+    "description": "This is a random plugin with no specific purpose.",
+    "tags": ["random", "test", "utility"],
+    "authors": [{ "name": "Author1", "email": "author1@example.com" }],
+    "dependencies": ["dependency1", "dependency2"],
+    "hasPatches": true,
+    "hasCommands": false,
+    "required": false,
+    "enabledByDefault": true,
+    "target": "discordDesktop",
+    "filePath": "/path/to/plugin1",
+    "github": "https://github.com/coolig",
+
+    "code": "console.log('hello world')",
+    "slug": "te",
+    "type": "js-snippet"
+}

--- a/src/content/third-party/plugins/test3.json
+++ b/src/content/third-party/plugins/test3.json
@@ -1,0 +1,17 @@
+{
+    "name": "Random Plugin 1",
+    "description": "This is a random plugin with no specific purpose.",
+    "tags": ["random", "test", "utility"],
+    "authors": [{ "name": "Author1", "email": "author1@example.com" }],
+    "dependencies": ["dependency1", "dependency2"],
+    "hasPatches": true,
+    "hasCommands": false,
+    "required": false,
+    "enabledByDefault": true,
+    "target": "discordDesktop",
+    "github": "https://github.com/plugin1",
+    "code": "",
+
+    "slug": "random-plugin-1",
+    "type": "plugin"
+}

--- a/src/content/third-party/plugins/test3.json
+++ b/src/content/third-party/plugins/test3.json
@@ -1,7 +1,7 @@
 {
     "name": "Random Plugin 1",
     "description": "This is a random plugin with no specific purpose.",
-    "tags": ["random", "test", "utility"],
+    "tags": ["utility"],
     "authors": [{ "name": "Author1", "email": "author1@example.com" }],
     "dependencies": ["dependency1", "dependency2"],
     "hasPatches": true,

--- a/src/pages/third-party/[resource].astro
+++ b/src/pages/third-party/[resource].astro
@@ -1,0 +1,72 @@
+---
+import Layout from "../../layouts/Layout.astro";
+import { cacheResponseFor, HOURS, MINUTES } from "../../scripts/cache";
+import { humanFriendlyJoin } from "../../scripts/text";
+import { getHighlighter } from "shiki";
+
+import Shiki from "../../components/ShikiCodeBlocks.svelte";
+import Info from "../../components/pages/thirdParty/Information.svelte";
+
+const fileData = await Astro.glob("../../content/third-party/**/*.json");
+const slug = Astro.params.resource;
+
+const r = fileData.find(file => file.slug === slug);
+
+const resourceTypeBeautified = {
+    plugin: "Plugin",
+    "js-snippet": "JS Snippet",
+    "css-snippet": "CSS Snippet",
+};
+
+if (!r) {
+    cacheResponseFor(Astro.response, 5 * MINUTES);
+    return {
+        status: 404,
+    };
+} else {
+    cacheResponseFor(Astro.response, 1 * HOURS);
+}
+
+const highlighter = await getHighlighter({
+    themes: ["catppuccin-frappe", "github-light"],
+    langs: ["javascript", "css", "shell"],
+});
+---
+
+<Layout title={slug} description=`Information for the resource`>
+    <div class="header">
+        <div>
+            <h1 class="p-page-title">{r.name}</h1>
+            <p class="p-subtitle">
+                by {
+                    humanFriendlyJoin(
+                        r.authors,
+                        (p: { name: string }) => p.name
+                    )
+                } • <span class="resource-type"
+                    >{resourceTypeBeautified[r.type]}</span
+                >
+            </p>
+
+            <p>{r.description}</p>
+        </div>
+    </div>
+
+    <Info
+        githubRepo={r.github}
+        code={r.code}
+        type={r.type}
+        {highlighter}
+        client:load
+    />
+</Layout>
+
+<style>
+    .resource-type {
+        color: var(--accentAqua);
+    }
+
+    .p-subtitle {
+        margin-top: 3px;
+    }
+</style>

--- a/src/pages/third-party/index.astro
+++ b/src/pages/third-party/index.astro
@@ -1,0 +1,27 @@
+---
+export const prerender = true;
+import Layout from "../../layouts/Layout.astro";
+import ResourceTabs from "../../components/pages/thirdParty/Resources.svelte";
+
+const fileData = await Astro.glob("../../content/third-party/**/*.json");
+const files = {
+    plugins: fileData.filter(file => file.type === "plugin"),
+    jsSnippet: fileData.filter(file => file.type === "js-snippet"),
+    cssSnippet: fileData.filter(file => file.type === "css-snippet"),
+};
+---
+
+<Layout
+    title="Third-Party"
+    description="Browse third-party resources such as snippets or plugins"
+    breadcrumbs={[["Third-Party", "/third-party"]]}
+>
+    <div>
+        <h1 class="p-page-title">Third-Party Resources</h1>
+        <p class="p-subtitle">
+            Discover a plethora of resources uploaded by the community wether
+            that be snippers or plugins
+        </p>
+    </div>
+    <ResourceTabs {files} client:load />
+</Layout>

--- a/src/scripts/types.ts
+++ b/src/scripts/types.ts
@@ -19,10 +19,10 @@ export interface PluginData {
     github?: string;
 }
 
-export interface Snippet {
+export interface MutualResource {
     name: string;
     description: string;
-    code: string;
     tags: string[];
     authors: PluginDev[];
+    filePath: string;
 }

--- a/src/scripts/types.ts
+++ b/src/scripts/types.ts
@@ -15,4 +15,14 @@ export interface PluginData {
     enabledByDefault: boolean;
     target: "discordDesktop" | "vencordDesktop" | "web" | "dev";
     filePath: string;
+
+    github?: string;
+}
+
+export interface Snippet {
+    name: string;
+    description: string;
+    code: string;
+    tags: string[];
+    authors: PluginDev[];
 }

--- a/src/styles/prose.css
+++ b/src/styles/prose.css
@@ -137,3 +137,7 @@ p {
         font-size: 4.5em;
     }
 }
+
+pre.shiki {
+    background-color: transparent !important;
+}


### PR DESCRIPTION
This Pull Request introduces the addition of Third-Party resources. This tab will contain the following resources:

- Third-Party Plugins
- JavaScript Snippets
- CSS Snippets

It includes filters allowing you to sort by Desktop/Web or search by name, author, and description.

To add plugins, you would create a .json file in src/content/third-party, structured as follows:
```json
{
    "name": "Album as Spotify Controls Background",
    "description": "Use album cover as SpotifyControls background",
    "tags": ["utility"],
    "authors": [{ "name": "Vee", "id": "343383572805058560" }],
    "dependencies": ["dependency1", "dependency2"],
    "hasPatches": false,
    "hasCommands": false,
    "required": false,
    "enabledByDefault": false,
    "target": "discordDesktop",
    "github": "", // Only required for plugins
    "code": "#vc-spotify-player {\n    --blur-amount: 2px; /* higher px = stronger blur, 0 = no blur */\n    --darken-percent: 0.8; /* 0 = album cover is not darkened, 1 = album cover is darkened fully (black) */\n}\n\n#vc-spotify-player {\n    background: transparent !important;\n    position: relative;\n}\n\n#vc-spotify-player > * {\n    position: relative;\n    z-index: 1;\n}\n\n#vc-spotify-player::after {\n    content: '';\n    position: absolute;\n    display: block;\n    height: 100%;\n    width: 100%;\n    top: 0;\n    left: 0;\n    background: linear-gradient(rgba(0, 0, 0, var(--darken-percent)),\n            rgba(0, 0, 0, var(--darken-percent))), var(--vc-spotify-track-image);\n    background-size: cover;\n    filter: blur(var(--blur-amount));\n    clip-path: inset(0);\n}", // Only required for snippets
    "slug": "spotify",
    "type": "css-snippet"
}
```

Important Details:
- Use `\n` to flatten the code within the JSON file. Various online tools can help with this process, ensuring proper formatting.[^1]
- The "type" field specifies the category of the resource, which can be either a `plugin`, `js-snippet`, or `css-snippet`.

<details>
    <summary><strong>Screenshots</strong></summary>
    <img width="1918" alt="Screenshot 2024-03-10 143852"
     src="https://github.com/Vencord/vencord.dev/assets/80976096/4d181ec3-c7cf-41fb-aebc-9db1751cbdc6"
    >
  <img width="1178" alt="image" src="https://github.com/Vencord/vencord.dev/assets/80976096/43de2e0b-48f7-4e1d-bbf9-ef4b52e12bfc">
<img width="1211" alt="image" src="https://github.com/Vencord/vencord.dev/assets/80976096/d7ddc215-c15e-4e6e-b80e-b1318d80a383">
<img width="1226" alt="image" src="https://github.com/Vencord/vencord.dev/assets/80976096/feee9ebc-3c97-4f43-84ca-1d32581381e2">
</details>

[^1]: I am considering swapping this to `.md` so you can just use codeblocks and also add your own custom information (as nessacary)