### PR TITLE
/download: stack buttons on small screen widths

### DIFF
--- a/src/components/pages/download/index.svelte
+++ b/src/components/pages/download/index.svelte
@@ -113,7 +113,7 @@
 
     @media screen and (max-width: 400px) {
         nav {
-            grid-template-columns: 1fr;
+            grid-template-columns: repeat(2, 1fr);
         }
         label {
             padding: 1em 0.75em;

--- a/src/components/pages/download/index.svelte
+++ b/src/components/pages/download/index.svelte
@@ -111,6 +111,15 @@
         }
     }
 
+    @media screen and (max-width: 400px) {
+        nav {
+            grid-template-columns: 1fr;
+        }
+        label {
+            padding: 1em 0.75em;
+        }
+    }
+
     label.selected {
         background-color: var(--accent);
         color: var(--bg2);


### PR DESCRIPTION
Smaller devices may have issues with the download buttons being over the edge of the screen if they're too small, so this change just makes them stack when it's under 400px.

###### Before
<img width="519" alt="image" src="https://github.com/Vencord/vencord.dev/assets/97859147/3fd20bb6-0773-4e4c-8c29-e5d8ba32b716">

###### After
<img width="519" alt="image" src="https://github.com/Vencord/vencord.dev/assets/97859147/1bc34906-7bdc-4ca8-acbf-10ac0ebce251">
