### PR TITLE
consistent border-radius

### DIFF
--- a/.prettierrc.yaml
+++ b/.prettierrc.yaml
@@ -5,3 +5,4 @@ tabWidth: 4
 trailingComma: es5
 semi: true
 printWidth: 80
+singleQuote: false

--- a/src/components/Card.svelte
+++ b/src/components/Card.svelte
@@ -15,7 +15,7 @@
     const background = kind + Math.floor(0xff / 12).toString(16);
 </script>
 
-<div style="--border:{border};--background:{background}">
+<div class="card" style="--border:{border};--background:{background}">
     <slot />
 </div>
 
@@ -23,7 +23,7 @@
     div {
         width: 100%;
         border: 2px solid var(--border);
-        border-radius: 12px;
+        border-radius: var(--br-md);
         padding: 0.5rem 1rem;
         margin: 0.5rem 0;
         box-sizing: border-box;

--- a/src/components/Card.svelte
+++ b/src/components/Card.svelte
@@ -29,4 +29,8 @@
         box-sizing: border-box;
         background-color: var(--background);
     }
+
+    :global(.card:last-child) {
+        margin-bottom: 0;
+    }
 </style>

--- a/src/components/Card.svelte
+++ b/src/components/Card.svelte
@@ -15,7 +15,7 @@
     const background = kind + Math.floor(0xff / 12).toString(16);
 </script>
 
-<div class="card" style="--border:{border};--background:{background}">
+<div style="--border:{border};--background:{background}">
     <slot />
 </div>
 
@@ -30,7 +30,7 @@
         background-color: var(--background);
     }
 
-    :global(.card:last-child) {
+    div:last-child {
         margin-bottom: 0;
     }
 </style>

--- a/src/components/Card.svelte
+++ b/src/components/Card.svelte
@@ -23,7 +23,7 @@
     div {
         width: 100%;
         border: 2px solid var(--border);
-        border-radius: var(--br-md);
+        border-radius: var(--border-md);
         padding: 0.5rem 1rem;
         margin: 0.5rem 0;
         box-sizing: border-box;

--- a/src/components/Code.astro
+++ b/src/components/Code.astro
@@ -4,7 +4,7 @@
     code {
         background-color: var(--bg2);
         color: var(--accentAqua);
-        border-radius: var(--br-xs);
+        border-radius: var(--border-xs);
         font-family: unset;
         text-align: center;
         padding: 0.05em 0.3em;

--- a/src/components/Code.astro
+++ b/src/components/Code.astro
@@ -4,7 +4,7 @@
     code {
         background-color: var(--bg2);
         color: var(--accentAqua);
-        border-radius: 8px;
+        border-radius: var(--br-xs);
         font-family: unset;
         text-align: center;
         padding: 0.05em 0.3em;

--- a/src/components/LinkButton.astro
+++ b/src/components/LinkButton.astro
@@ -22,7 +22,7 @@ export interface Props extends HTMLAttributes<"a"> {
         color: var(--fg0);
         outline: 2px solid var(--fg0-muted);
         padding: 0.8em 2em;
-        border-radius: var(--br-md);
+        border-radius: var(--border-md);
 
         transition: 200ms color ease;
     }

--- a/src/components/LinkButton.astro
+++ b/src/components/LinkButton.astro
@@ -22,7 +22,7 @@ export interface Props extends HTMLAttributes<"a"> {
         color: var(--fg0);
         outline: 2px solid var(--fg0-muted);
         padding: 0.8em 2em;
-        border-radius: 12px;
+        border-radius: var(--br-md);
 
         transition: 200ms color ease;
     }

--- a/src/components/RepoCard.astro
+++ b/src/components/RepoCard.astro
@@ -54,7 +54,7 @@ avatarUrl.searchParams.set("size", "64");
         background: var(--bg4);
         border: 1px solid var(--color-semi-trans);
         padding: 1em;
-        border-radius: var(--br-lg);
+        border-radius: var(--border-lg);
         display: grid;
 
         transition: 200ms box-shadow cubic-bezier(0.25, 0.8, 0.25, 1);

--- a/src/components/RepoCard.astro
+++ b/src/components/RepoCard.astro
@@ -54,7 +54,7 @@ avatarUrl.searchParams.set("size", "64");
         background: var(--bg4);
         border: 1px solid var(--color-semi-trans);
         padding: 1em;
-        border-radius: 12px;
+        border-radius: var(--br-lg);
         display: grid;
 
         transition: 200ms box-shadow cubic-bezier(0.25, 0.8, 0.25, 1);

--- a/src/components/pages/download/BrowserTab.astro
+++ b/src/components/pages/download/BrowserTab.astro
@@ -156,14 +156,14 @@ const Chromiums = [
     }
 
     .chrome-badge {
-        border-radius: 12px;
+        border-radius: var(--br-lg);
     }
 
     .userscript-badge {
         height: 58px;
         width: 180px;
         padding: 4px 8px;
-        border-radius: 12px;
+        border-radius: var(--br-lg);
         box-sizing: border-box;
         display: flex;
         align-items: center;
@@ -174,16 +174,7 @@ const Chromiums = [
     .userscript-badge img {
         height: 90%;
     }
-    party
-        extensions
-        unless
-        they
-        are
-        signed
-        (which also requires store approval).
-        As
-        such,
-    it is not possible for us to offer a Firefox extension. .userscript-text {
+    .userscript-text {
         margin-left: 12px;
     }
 

--- a/src/components/pages/download/BrowserTab.astro
+++ b/src/components/pages/download/BrowserTab.astro
@@ -156,14 +156,14 @@ const Chromiums = [
     }
 
     .chrome-badge {
-        border-radius: var(--br-lg);
+        border-radius: var(--border-lg);
     }
 
     .userscript-badge {
         height: 58px;
         width: 180px;
         padding: 4px 8px;
-        border-radius: var(--br-lg);
+        border-radius: var(--border-lg);
         box-sizing: border-box;
         display: flex;
         align-items: center;

--- a/src/components/pages/download/index.svelte
+++ b/src/components/pages/download/index.svelte
@@ -89,7 +89,7 @@
         background-color: var(--bgCurrentWord);
         padding: 1rem;
 
-        border-radius: var(--br-xl);
+        border-radius: var(--border-xl);
     }
 
     label {
@@ -100,7 +100,7 @@
         padding: 1.25em 1.5rem;
         text-align: center;
         cursor: pointer;
-        border-radius: var(--br-lg);
+        border-radius: var(--border-lg);
 
         background-color: var(--bg3);
     }

--- a/src/components/pages/download/index.svelte
+++ b/src/components/pages/download/index.svelte
@@ -128,8 +128,4 @@
     input {
         display: none;
     }
-
-    :global(.card:last-of-type) {
-        margin-bottom: 0;
-    }
 </style>

--- a/src/components/pages/download/index.svelte
+++ b/src/components/pages/download/index.svelte
@@ -89,7 +89,7 @@
         background-color: var(--bgCurrentWord);
         padding: 1rem;
 
-        border-radius: 16px;
+        border-radius: var(--br-xl);
     }
 
     label {
@@ -100,7 +100,7 @@
         padding: 1.25em 1.5rem;
         text-align: center;
         cursor: pointer;
-        border-radius: 12px;
+        border-radius: var(--br-lg);
 
         background-color: var(--bg3);
     }
@@ -127,5 +127,9 @@
 
     input {
         display: none;
+    }
+
+    :global(.card:last-of-type) {
+        margin-bottom: 0;
     }
 </style>

--- a/src/components/pages/plugins/Plugins.svelte
+++ b/src/components/pages/plugins/Plugins.svelte
@@ -202,7 +202,7 @@
         flex-direction: column;
         background: var(--bg4);
 
-        border-radius: 12px;
+        border-radius: var(--br-lg);
         padding: 1em;
         padding-bottom: 2em;
 
@@ -221,7 +221,7 @@
     .plugin-screenshot {
         object-fit: cover;
         width: 100%;
-        border-radius: 4px;
+        border-radius: var(--br-sm);
         margin-bottom: 1em;
     }
 
@@ -322,7 +322,7 @@
         background: var(--bg0);
         color: var(--fg0);
         border: none;
-        border-radius: 12px;
+        border-radius: var(--br-lg);
         box-sizing: border-box;
         width: 100%;
         margin: 1em 0;

--- a/src/components/pages/plugins/Plugins.svelte
+++ b/src/components/pages/plugins/Plugins.svelte
@@ -202,7 +202,7 @@
         flex-direction: column;
         background: var(--bg4);
 
-        border-radius: var(--br-lg);
+        border-radius: var(--border-lg);
         padding: 1em;
         padding-bottom: 2em;
 
@@ -221,7 +221,7 @@
     .plugin-screenshot {
         object-fit: cover;
         width: 100%;
-        border-radius: var(--br-sm);
+        border-radius: var(--border-sm);
         margin-bottom: 1em;
     }
 
@@ -322,7 +322,7 @@
         background: var(--bg0);
         color: var(--fg0);
         border: none;
-        border-radius: var(--br-lg);
+        border-radius: var(--border-lg);
         box-sizing: border-box;
         width: 100%;
         margin: 1em 0;

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -262,11 +262,11 @@ if (Astro.url.pathname === "/") {
         --astro-code-token-link: var(--accentBlue);
 
         /* Border Radius */
-        --br-xl: 20px;
-        --br-lg: 16px;
-        --br-md: 12px;
-        --br-sm: 8px;
-        --br-xs: 4px;
+        --border-xl: 20px;
+        --border-lg: 16px;
+        --border-md: 12px;
+        --border-sm: 8px;
+        --border-xs: 4px;
     }
 
     /* Light class */

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -260,6 +260,13 @@ if (Astro.url.pathname === "/") {
         --astro-code-token-function: var(--accentGreen);
         --astro-code-token-punctuation: var(--fg0);
         --astro-code-token-link: var(--accentBlue);
+
+        /* Border Radius */
+        --br-xl: 20px;
+        --br-lg: 16px;
+        --br-md: 12px;
+        --br-sm: 8px;
+        --br-xs: 4px;
     }
 
     /* Light class */

--- a/src/pages/faq.astro
+++ b/src/pages/faq.astro
@@ -94,7 +94,7 @@ const structuredData = JSON.stringify({
     details {
         background-color: var(--bg3);
         padding: 1em 1em;
-        border-radius: var(--br-lg);
+        border-radius: var(--border-lg);
     }
 
     summary {
@@ -109,7 +109,7 @@ const structuredData = JSON.stringify({
     .faq-content {
         background-color: var(--bgCurrentWord);
         color: var(--grey2);
-        border-radius: var(--br-md);
+        border-radius: var(--border-md);
         padding: 0.75em;
     }
 
@@ -125,7 +125,7 @@ const structuredData = JSON.stringify({
 
     .questions :global(code:not(pre > code)) {
         background-color: var(--bg1);
-        border-radius: var(--br-xs);
+        border-radius: var(--border-xs);
         text-align: center;
         padding: 0 4px;
         margin: 0 2px;
@@ -134,6 +134,6 @@ const structuredData = JSON.stringify({
     .questions :global(.astro-code) {
         padding: 1em;
         background-color: var(--bg1) !important;
-        border-radius: var(--br-sm);
+        border-radius: var(--border-sm);
     }
 </style>

--- a/src/pages/faq.astro
+++ b/src/pages/faq.astro
@@ -53,7 +53,7 @@ const structuredData = JSON.stringify({
         We're happy to help.
     </p>
 
-    <script type="application/ld+json" set:html={structuredData}></script>
+    <script type="application/ld+json" set:html={structuredData} />
 </Layout>
 
 <script>
@@ -94,7 +94,7 @@ const structuredData = JSON.stringify({
     details {
         background-color: var(--bg3);
         padding: 1em 1em;
-        border-radius: 12px;
+        border-radius: var(--br-lg);
     }
 
     summary {
@@ -109,9 +109,8 @@ const structuredData = JSON.stringify({
     .faq-content {
         background-color: var(--bgCurrentWord);
         color: var(--grey2);
-        border-radius: 8px;
+        border-radius: var(--br-md);
         padding: 0.75em;
-        margin-bottom: 0.25em;
     }
 
     details :global(p) {
@@ -126,7 +125,7 @@ const structuredData = JSON.stringify({
 
     .questions :global(code:not(pre > code)) {
         background-color: var(--bg1);
-        border-radius: 5px;
+        border-radius: var(--br-xs);
         text-align: center;
         padding: 0 4px;
         margin: 0 2px;
@@ -135,6 +134,6 @@ const structuredData = JSON.stringify({
     .questions :global(.astro-code) {
         padding: 1em;
         background-color: var(--bg1) !important;
-        border-radius: 6px;
+        border-radius: var(--br-sm);
     }
 </style>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -157,7 +157,7 @@ if (features.length % 3 !== 0)
     .feature-card {
         background-color: var(--bg4);
         padding: 16px;
-        border-radius: 12px;
+        border-radius: var(--br-lg);
 
         transition: 200ms box-shadow cubic-bezier(0.25, 0.8, 0.25, 1);
     }
@@ -167,7 +167,7 @@ if (features.length % 3 !== 0)
         width: 1.5em;
         height: 1.5em;
         background-color: var(--bgCurrentWord);
-        border-radius: 8px;
+        border-radius: var(--br-md);
     }
 
     .feature-icon img {

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -157,7 +157,7 @@ if (features.length % 3 !== 0)
     .feature-card {
         background-color: var(--bg4);
         padding: 16px;
-        border-radius: var(--br-lg);
+        border-radius: var(--border-lg);
 
         transition: 200ms box-shadow cubic-bezier(0.25, 0.8, 0.25, 1);
     }
@@ -167,7 +167,7 @@ if (features.length % 3 !== 0)
         width: 1.5em;
         height: 1.5em;
         background-color: var(--bgCurrentWord);
-        border-radius: var(--br-md);
+        border-radius: var(--border-md);
     }
 
     .feature-icon img {

--- a/src/pages/plugins/[plugin].astro
+++ b/src/pages/plugins/[plugin].astro
@@ -94,7 +94,7 @@ const readmeHtml = processedReadme && parseMarkdown(processedReadme);
     article {
         background: var(--bgCurrentWord);
         padding: 2em;
-        border-radius: var(--br-xl);
+        border-radius: var(--border-xl);
     }
 
     /*

--- a/src/pages/plugins/[plugin].astro
+++ b/src/pages/plugins/[plugin].astro
@@ -94,7 +94,7 @@ const readmeHtml = processedReadme && parseMarkdown(processedReadme);
     article {
         background: var(--bgCurrentWord);
         padding: 2em;
-        border-radius: 16px;
+        border-radius: var(--br-xl);
     }
 
     /*

--- a/src/styles/prose.css
+++ b/src/styles/prose.css
@@ -64,7 +64,7 @@ p {
 .p-display {
     font-size: 6em;
     font-weight: var(--fontWeightBold);
-    letter-spacing: -0.02rem;
+    letter-spacing: -0.02em;
     line-height: 7.25rem;
 }
 


### PR DESCRIPTION
- added variables for border-radius (i did increase the overall border-radius for some elements just to create better looking nested round corners, i can revert to before if you want)
```
--br-xl: 20px;
--br-lg: 16px;
--br-md: 12px;
--br-sm: 8px;
--br-xs: 4px;
```
- fixed uneven vertical and horizontal padding on faq cards and download tabs
- changed `letter-spacing` on main headline to use `em` instead of `rem` (so it actually does something now)
- fixed accidental paste in `BrowserTab.astro`
- prettierrc addition because vscode kept converting everything to single quotes