### PR TITLE
Use non expired discord invite.

### DIFF
--- a/scripts/generateRedirects.mjs
+++ b/scripts/generateRedirects.mjs
@@ -2,8 +2,8 @@ import { readFileSync, writeFileSync } from "fs";
 
 const BaseRedirects = {
     "/github": "https://github.com/Vendicated/Vencord",
-    "/discord": "https://discord.gg/D9uwnFnqmd",
-    "/support": "https://discord.gg/D9uwnFnqmd",
+    "/discord": "https://discord.gg/vencord",
+    "/support": "https://discord.gg/vencord",
     "/install": "/download",
     "/plugins.json":
         "https://raw.githubusercontent.com/Vencord/builds/main/plugins.json",

--- a/src/scripts/constants.ts
+++ b/src/scripts/constants.ts
@@ -1,4 +1,4 @@
-export const DISCORD_INVITE = "https://discord.gg/D9uwnFnqmd";
+export const DISCORD_INVITE = "https://discord.gg/vencord";
 export const GITHUB_URL = "https://github.com/Vendicated/Vencord";
 export const SOURCE_CODE = "https://github.com/Vencord/vencord.dev";
 export const VENCORD_CLOUD_SOURCE_CODE_URL =


### PR DESCRIPTION
Fixes the current invite (expired) with the vanity. 

(If we lose vanity invite we will need to change to a non-expired invite.)