### PR TITLE
Fix wording for linux installation

### DIFF
--- a/src/components/pages/download/LinuxTab.astro
+++ b/src/components/pages/download/LinuxTab.astro
@@ -9,7 +9,8 @@ import Card, { CardKind } from "components/Card.svelte";
     <div slot="header">
         <p class="instruction">
             Open your terminal and run the following command. Then follow the
-            instructions in your terminal. If you're using fish, switch to bash
+            instructions in your terminal. If you're using a non posix
+            compliant shell, switch to a posix complaint shell like bash
             first (by running
             {}
             <Code>bash</Code>)


### PR DESCRIPTION
Fix the wording on the Linux installation page to make it clear that the shell script requires a POSIX compliant shell.