### PR TITLE
Use system shell instead of interactive shell

### DIFF
--- a/src/components/pages/download/LinuxTab.astro
+++ b/src/components/pages/download/LinuxTab.astro
@@ -9,13 +9,10 @@ import Card, { CardKind } from "components/Card.svelte";
     <div slot="header">
         <p class="instruction">
             Open your terminal and run the following command. Then follow the
-            instructions in your terminal. If you're using fish, switch to bash
-            first (by running
-            {}
-            <Code>bash</Code>)
+            instructions in your terminal.
         </p>
         <CodeBlock
-            code={'sh -c "$(curl -sS https://raw.githubusercontent.com/Vendicated/VencordInstaller/main/install.sh)"'}
+            code={'curl -sS https://raw.githubusercontent.com/Vendicated/VencordInstaller/main/install.sh | /bin/sh'}
             client:load
         />
     </div>


### PR DESCRIPTION
This pull request is intended to be a fix up of #65. When the install script is downloaded, it is ran using the user's **interactive shell** instead of their **system shell** (try running `sh -c "echo $0"`). The current documentation says this could be mitigated by instructing the user to switch their interactive shell, however, this issue can be avoided entirely by using the system shell(`/bin/sh`) which is usually used for script execution anyways.