### PR TITLE
download/mac: remove reference to devbuild of macOS

### DIFF
--- a/src/components/pages/download/MacTab.astro
+++ b/src/components/pages/download/MacTab.astro
@@ -18,9 +18,9 @@ import Tab from "./Tab.astro";
         </p>
 
         <p>
-            If you are using the developer build of macOS Sequoia, or if
-            right-clicking isn't working for you, you can allow the app to run
-            through your System Settings. <a
+            If you are using macOS Sequoia, or if right-clicking isn't working 
+            for you, you can allow the app to run through your System Settings. 
+            <a
                 href="https://support.apple.com/102445#openanyway"
                 rel="noopener noreferrer"
                 >Learn more


### PR DESCRIPTION
macOS Seqouia 15.1 is now generally available, so the note about being on a devbuild is outdated, it happens on the latest public build too