### PR TITLE
chore: update mobile faq command to not mention vendroid

### DIFF
--- a/src/content/faq/4_mobile.md
+++ b/src/content/faq/4_mobile.md
@@ -7,5 +7,5 @@ Vencord is made for Discord web and does not support the mobile versions of Disc
 
 Instead, we recommend the following alternatives:
 
--   [Pyoncord](https://github.com/pyoncord/Pyoncord) ([discord server](https://discord.gg/XjYgWXHb9Q)) ~ Supports both Android & iOS. Uses the latest Discord mobile app.
+-   [Bunny](https://github.com/pyoncord/Pyoncord) ([discord server](https://discord.gg/XjYgWXHb9Q)) ~ Supports both Android & iOS. Uses the latest Discord mobile app.
 -   [Aliucord](https://aliucord.com) ([discord server](https://discord.gg/EsNDvBaHVU)) ~ Android only. Uses the old kotlin version of the Discord Android app.

--- a/src/content/faq/4_mobile.md
+++ b/src/content/faq/4_mobile.md
@@ -3,9 +3,9 @@ title: Is there a mobile version of Vencord?
 tags: android, ios, mobile, phone
 ---
 
-Technically yes, we have a very barebones app for android: [Vendroid](<https://github.com/Vencord/Vendroid>)
-However, it suffers from many issues and thus is not recommended for daily use (nor is it actively being worked on)
+Vencord is made for Discord web and does not support the mobile versions of Discord found on the App Store or Play Store, while there is proof of concepts regarding using Discords mobile website, **we don't recommend using those.**
 
 Instead, we recommend the following alternatives:
-- [Pyoncord](<https://github.com/pyoncord/Pyoncord>) ([discord server](<https://discord.gg/XjYgWXHb9Q>)) ~ supports both android & ios. uses the latest discord mobile app
-- [Aliucord](<https://aliucord.com>) ([discord server](<https://discord.gg/EsNDvBaHVU>)) ~ android only. uses the old (now ~2 years old) version of the discord android app
+
+-   [Pyoncord](https://github.com/pyoncord/Pyoncord) ([discord server](https://discord.gg/XjYgWXHb9Q)) ~ Supports both Android & iOS. Uses the latest Discord mobile app.
+-   [Aliucord](https://aliucord.com) ([discord server](https://discord.gg/EsNDvBaHVU)) ~ Android only. Uses the old kotlin version of the Discord Android app.


### PR DESCRIPTION
While Vendroid is a cool concept, the faq command often confuses newcomers since they don't often read the entirety of the information presented to them, so we edit the command to avoid linking to Vendroid so we can lead users to more proper client mods.