### PR TITLE
Fix broken Certum code signing link in installer warning.

### DIFF
--- a/src/components/pages/download/WindowsTab.astro
+++ b/src/components/pages/download/WindowsTab.astro
@@ -36,7 +36,7 @@ cd Downloads
             <p>
                 This warning is entirely harmless and only shows because the app
                 is not signed. Signing it would cost us <a
-                    href="https://shop.certum.eu/data-safety/code-signing-certificates/certum-ev-code-sigining.html"
+                    href="https://shop.certum.eu/certum-ev-code-sigining-code.html"
                     >upwards of 300€/year</a
                 >.
             </p>


### PR DESCRIPTION
Updates the Certum EV code signing certificate link in the installer warning card to the correct URL.

No functional changes.